### PR TITLE
Fix manual recipe form layout and mobile spacing

### DIFF
--- a/app/add-recipe/components/AddRecipeForm.tsx
+++ b/app/add-recipe/components/AddRecipeForm.tsx
@@ -12,9 +12,8 @@ function AddRecipeForm() {
   };
 
   return (
-    <div>
-      {isManual ? <ManualForm /> : <RecipeURLForm />}
-      <div className="mt-4 flex items-center justify-center gap-2">
+    <div className="pb-8">
+      <div className="mb-6 flex items-center justify-center gap-2">
         <label className={`text-sm transition-colors ${isManual ? "text-tertiary/70" : "text-tertiary font-medium"}`}>Enter URL</label>
         <button
           onClick={onToggle}

--- a/app/add-recipe/components/AddRecipeForm.tsx
+++ b/app/add-recipe/components/AddRecipeForm.tsx
@@ -13,7 +13,7 @@ function AddRecipeForm() {
 
   return (
     <div className="pb-8">
-      <div className="mb-6 flex items-center justify-center gap-2">
+      <div className="mt-4 mb-6 flex items-center justify-center gap-2 max-w-md mx-auto">
         <label className={`text-sm transition-colors ${isManual ? "text-tertiary/70" : "text-tertiary font-medium"}`}>Enter URL</label>
         <button
           onClick={onToggle}

--- a/app/add-recipe/components/RecipeURLForm.tsx
+++ b/app/add-recipe/components/RecipeURLForm.tsx
@@ -11,6 +11,15 @@ export default function RecipeURLForm() {
   const [badURL, setBadURL] = useState("");
   const [isError, setIsError] = useState(false);
 
+  const isValidURL = (url: string) => {
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === "http:" || parsed.protocol === "https:";
+    } catch {
+      return false;
+    }
+  };
+
   const handleRecipeSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     try {
       e.preventDefault();
@@ -54,7 +63,10 @@ export default function RecipeURLForm() {
           placeholder="Recipe URL"
           autoFocus
         />
-        <button className="bg-pop hover:bg-pop/80 text-tertiary rounded-md px-3 py-1.5 whitespace-nowrap transition-colors">
+        <button
+          disabled={!isValidURL(recipeURL)}
+          className="bg-pop hover:bg-pop/80 text-tertiary rounded-md px-3 py-1.5 whitespace-nowrap transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
           Enter Recipe
         </button>
       </form>

--- a/app/add-recipe/components/manualform/ListInput.tsx
+++ b/app/add-recipe/components/manualform/ListInput.tsx
@@ -7,6 +7,7 @@ function ListInput({
   onRemove,
   onReorder,
   placeholder,
+  addLabel,
   useTextarea = false,
 }: {
   items: string[];
@@ -14,6 +15,7 @@ function ListInput({
   onRemove: (index: number) => void;
   onReorder: (index: number, direction: "up" | "down") => void;
   placeholder: string;
+  addLabel: string;
   useTextarea?: boolean;
 }) {
   const [value, setValue] = useState("");
@@ -66,18 +68,18 @@ function ListInput({
           ))}
         </ul>
       )}
-      <form onSubmit={handleSubmit} className="flex items-start gap-2 max-w-sm mx-auto">
+      <form onSubmit={handleSubmit} className="max-w-sm mx-auto">
         <InputElement
-          className="flex-1 rounded-md bg-primary text-tertiary placeholder-tertiary/40 px-4 py-2 border border-white/10 focus:border-accent focus:outline-none resize-y"
+          className="w-full rounded-md bg-primary text-tertiary placeholder-tertiary/40 px-4 py-2 border border-white/10 focus:border-accent focus:outline-none resize-y"
           placeholder={placeholder}
           value={value}
           onChange={(e) => setValue(e.target.value)}
         />
         <button
           type="submit"
-          className="text-accent hover:text-accent-hover pt-2 transition-colors"
+          className="flex items-center gap-1.5 mx-auto mt-2 text-sm text-accent hover:text-accent-hover transition-colors"
         >
-          <Plus size={22} />
+          {addLabel} <Plus size={16} />
         </button>
       </form>
     </div>

--- a/app/add-recipe/components/manualform/ManualForm.tsx
+++ b/app/add-recipe/components/manualform/ManualForm.tsx
@@ -146,6 +146,7 @@ function ManualForm() {
               onRemove={(idx) => dispatch({ type: "REMOVE_ITEM", field: "keywords", index: idx })}
               onReorder={(idx, dir) => dispatch({ type: "REORDER_ITEM", field: "keywords", index: idx, direction: dir })}
               placeholder="Enter Keyword..."
+              addLabel="Add Keyword"
             />
           </div>
         </section>
@@ -161,6 +162,7 @@ function ManualForm() {
               onRemove={(idx) => dispatch({ type: "REMOVE_ITEM", field: "ingredients", index: idx })}
               onReorder={(idx, dir) => dispatch({ type: "REORDER_ITEM", field: "ingredients", index: idx, direction: dir })}
               placeholder="Enter Ingredient"
+              addLabel="Add Ingredient"
               useTextarea
             />
           </div>
@@ -172,6 +174,7 @@ function ManualForm() {
               onRemove={(idx) => dispatch({ type: "REMOVE_ITEM", field: "instructions", index: idx })}
               onReorder={(idx, dir) => dispatch({ type: "REORDER_ITEM", field: "instructions", index: idx, direction: dir })}
               placeholder="Enter Instruction"
+              addLabel="Add Instruction"
               useTextarea
             />
           </div>

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -14,7 +14,7 @@ export default async function Header() {
           <a href="/">Ko-Mi</a>
         </h1>
       </div>
-      <nav className="flex justify-center gap-2 sm:gap-4 px-4">
+      <nav className="flex justify-center gap-2 sm:gap-4 px-6 sm:px-4">
         <NavLink href="/" label="Recipes" icon="utensils" />
         <NavLink href="/add-recipe" label="Add Recipe" icon="plus" />
         <NavLink href="/shopping-list" label="Shopping List" icon="cart" />

--- a/app/components/NavLink.tsx
+++ b/app/components/NavLink.tsx
@@ -25,7 +25,7 @@ export default function NavLink({
   return (
     <Link
       href={href}
-      className={`flex items-center gap-1.5 sm:gap-1.5 px-4 sm:px-4 py-2 sm:py-2 rounded-lg text-sm sm:text-lg font-medium whitespace-nowrap transition-all duration-200 ${
+      className={`flex items-center gap-1.5 px-3 sm:px-4 py-2 rounded-lg text-sm sm:text-lg font-medium whitespace-nowrap transition-all duration-200 ${
         isActive
           ? "bg-pop text-white shadow-md"
           : "text-tertiary/70 hover:text-accent hover:bg-white/10"

--- a/app/components/Toast.tsx
+++ b/app/components/Toast.tsx
@@ -12,7 +12,7 @@ function Toast({
   const bg = variant === "success" ? "bg-green-600" : "bg-amber-500";
 
   return (
-    <div role="alert" className={`fixed top-4 left-1/2 z-50 ${bg} text-white px-6 py-3 rounded-lg shadow-lg flex items-center gap-2 animate-toast-in`}>
+    <div role="alert" className={`fixed bottom-4 right-4 z-50 ${bg} text-white px-6 py-3 rounded-lg shadow-lg flex items-center gap-2 animate-toast-in`}>
       <span>{message}</span>
       <button onClick={onClose} aria-label="Dismiss" className="ml-2 font-bold">×</button>
     </div>

--- a/app/components/homepage/userselectors/UserSelectors.tsx
+++ b/app/components/homepage/userselectors/UserSelectors.tsx
@@ -3,7 +3,7 @@ import UserToggle from "./UserToggle";
 
 export default function UserSelectors({ random }: { random: string }) {
   return (
-    <div className="flex flex-wrap items-center justify-center gap-3 pb-2">
+    <div className="flex flex-wrap items-center justify-center gap-1 sm:gap-3 pb-2">
       <UserToggle />
       <RandomButton random={random} />
     </div>

--- a/app/components/homepage/userselectors/UserToggle.tsx
+++ b/app/components/homepage/userselectors/UserToggle.tsx
@@ -28,8 +28,8 @@ export default function UserToggle() {
       <button
         className={
           !all
-            ? "mx-4 underline hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent rounded"
-            : "mx-4 hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent rounded"
+            ? "mx-2 sm:mx-4 underline hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent rounded"
+            : "mx-2 sm:mx-4 hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent rounded"
         }
         onClick={toggleMyRecipes}
       >
@@ -39,8 +39,8 @@ export default function UserToggle() {
       <button
         className={
           all
-            ? "mx-4 underline hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent rounded"
-            : "mx-4 hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent rounded"
+            ? "mx-2 sm:mx-4 underline hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent rounded"
+            : "mx-2 sm:mx-4 hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent rounded"
         }
         onClick={toggleAllRecipes}
       >


### PR DESCRIPTION
## Summary
- Fix duplicate manual recipe form rendering and reposition the URL/manual toggle above the form
- Improve mobile spacing for nav buttons, recipe selectors, and form toggle
- Move add button below list inputs with descriptive "Add {step}" labels
- Move all toasts to bottom-right of screen
- Add URL validation to disable submit for invalid URLs

## Test plan
- [ ] Verify manual recipe form renders once with toggle above
- [ ] Check nav buttons and recipe selectors have adequate spacing on iPhone 12
- [ ] Confirm "Add Ingredient/Instruction/Keyword" buttons appear below inputs
- [ ] Verify toasts appear in bottom-right corner
- [ ] Test URL input rejects invalid URLs and enables submit for valid ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)